### PR TITLE
Compatibility fix for aeson-1.2.2.0

### DIFF
--- a/src/Network/DO/Droplets/Net.hs
+++ b/src/Network/DO/Droplets/Net.hs
@@ -86,7 +86,7 @@ doSshInDroplet w droplet =   let r = maybe (return $ error ("droplet " <> show d
                                      (publicIP droplet)
                              in (r, w)
 
-waitForBoxToBeUp :: (Monad m) => Options -> Int -> Droplet -> RESTT m (Result Droplet)
+waitForBoxToBeUp :: (Monad m) => Network.REST.Options -> Int -> Droplet -> RESTT m (Result Droplet)
 waitForBoxToBeUp _    0 box  = return (Right box)
 waitForBoxToBeUp opts n box  = do
   waitFor 1000000 ("waiting for droplet " ++ name box ++ " to become Active: " ++ show (n) ++ "s")


### PR DESCRIPTION
`aeson` 1.2.20 (released Sep 20, 2017) exports an [Options](https://hackage.haskell.org/package/aeson-1.2.2.0/docs/Data-Aeson.html#t:Options) type that causes a conflict with this code.

I've qualified the use of the `Options` type so that this library will still continue to compile with older versions of aeson